### PR TITLE
Add collected breeds to tooltip during pet battle

### DIFF
--- a/BattlePetBreedID.lua
+++ b/BattlePetBreedID.lua
@@ -501,6 +501,7 @@ local function BPBID_Events_OnEvent(self, event, name, ...)
             BPBID_Options.Breedtip.CurrentStats25Rare = true -- Always assume pet will be Rare at level 25
             BPBID_Options.Breedtip.AllStats25 = true -- All breeds' stats at level 25
             BPBID_Options.Breedtip.AllStats25Rare = true -- Always assume pet will be Rare at level 25
+            BPBID_Options.Breedtip.Collected = true -- Collected breeds for current pet
             
             BPBID_Options.BattleFontFix = false -- Test old Pet Battle rarity coloring
         end

--- a/BreedTooltips.lua
+++ b/BreedTooltips.lua
@@ -107,6 +107,27 @@ function BPBID_SetBreedTooltip(parent, speciesID, tblBreedID, rareness, tooltipD
         breedtip:AddLine(current, 1, 1, 1, 1)
     end
 
+    if (BPBID_Options.Breedtip.Collected) then
+        C_PetJournal.ClearSearchFilter()
+        numPets, numOwned = C_PetJournal.GetNumPets()
+        local collectedPets = {}
+        for i = 1, numPets do
+            local petID, speciesID2, owned, customName, level, favorite, isRevoked, speciesName, icon, petType, companionID, tooltip, description, isWild, canBattle, isTradeable, isUnique, obtainable = C_PetJournal.GetPetInfoByIndex(i)
+            if speciesID2 == speciesID then 
+                local speciesID, customName, level, xp, maxXp, displayID, isFavorite, name, icon, petType, creatureID, sourceText, description, isWild, canBattle, tradable, unique, obtainable = C_PetJournal.GetPetInfoByPetID(petID)
+                local health, maxHealth, power, speed, rarity = C_PetJournal.GetPetStats(petID)
+
+                local breedNum, quality, resultslist = internal.CalculateBreedID(speciesID, rarity, level, maxHealth, power, speed, false, false)
+
+                local breed = internal.RetrieveBreedName(breedNum)
+                table.insert(collectedPets, ITEM_QUALITY_COLORS[quality-1].hex .. "L" .. level .. " (" .. breed .. ")"  .. "|r")
+            end
+        end
+        if (#collectedPets > 0) then
+            breedtip:AddLine("\124cFFD4A017Collected:\124r " .. table.concat(collectedPets, ", "), 1, 1, 1, 1)
+        end
+    end
+
     -- Set line for "Current pet's possible breeds"
     if (BPBID_Options.Breedtip.Possible) then
         local possible = "\124cFFD4A017Possible Breed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Battle Pet BreedID
+
+## [v1.28.0](https://github.com/MMOSimca/BattlePetBreedID/tree/v1.28.0) (2024-05-11)
+[Full Changelog](https://github.com/MMOSimca/BattlePetBreedID/compare/v1.27.0...v1.28.0) [Previous Releases](https://github.com/MMOSimca/BattlePetBreedID/releases)
+
+- Updated Interface version for Patch 10.2.7.  
+- Updated base stats and breed data for all recent pets.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Battle Pet BreedID
-
-## [v1.28.0](https://github.com/MMOSimca/BattlePetBreedID/tree/v1.28.0) (2024-05-11)
-[Full Changelog](https://github.com/MMOSimca/BattlePetBreedID/compare/v1.27.0...v1.28.0) [Previous Releases](https://github.com/MMOSimca/BattlePetBreedID/releases)
-
-- Updated Interface version for Patch 10.2.7.  
-- Updated base stats and breed data for all recent pets.  

--- a/OptionsPanel.lua
+++ b/OptionsPanel.lua
@@ -197,6 +197,7 @@ breedtipTitle:SetTextColor(1, 1, 1, 1)
 -- Make Breedtip checkboxes
 local OptBreedtipCurrent = CreateCheckbox("Current pet's breed", 32, 32, "TOPLEFT", breedtipTitle, "BOTTOMLEFT", 0, 0)
 local OptBreedtipPossible = CreateCheckbox("Current pet's possible breeds", 32, 32, "TOPLEFT", lastcheckbox, "BOTTOMLEFT", 0, 0)
+local OptBreedtipCollected = CreateCheckbox("Current's pet collected breeds", 32, 32, "TOPLEFT", lastcheckbox, "BOTTOMLEFT", 0, 0)
 local OptBreedtipSpeciesBase = CreateCheckbox("Pet species' base stats", 32, 32, "TOPLEFT", lastcheckbox, "BOTTOMLEFT", 0, 0)
 local OptBreedtipCurrentStats = CreateCheckbox("Current breed's base stats", 32, 32, "TOPLEFT", lastcheckbox, "BOTTOMLEFT", 0, 0)
 local OptBreedtipAllStats = CreateCheckbox("All breed's base stats", 32, 32, "TOPLEFT", lastcheckbox, "BOTTOMLEFT", 0, 0)
@@ -246,6 +247,7 @@ local function BPBID_Options_Refresh()
     OptBreedtipAllStats25:SetChecked(BPBID_Options.Breedtip.AllStats25)
     OptBreedtipAllStats25Rare:SetChecked(BPBID_Options.Breedtip.AllStats25Rare)
     OptBugBattleFontFix:SetChecked(BPBID_Options.BattleFontFix)
+    OptBreedtipCollected:SetChecked(BPBID_Options.Breedtip.Collected)
 
     -- Enable/disable dependent checkboxes
     if (OptNamesHSFUpdate:GetChecked()) then
@@ -272,6 +274,7 @@ local function BPBID_Options_Refresh()
         OptBreedtipCurrentStats25Rare:Enable()
         OptBreedtipAllStats25:Enable()
         OptBreedtipAllStats25Rare:Enable()
+        OptBreedtipCollected:Enable()
     elseif (not OptTooltipsEnabled:GetChecked()) then
         OptTooltipsBattleTooltip:Disable()
         OptTooltipsBPT:Disable()
@@ -286,6 +289,7 @@ local function BPBID_Options_Refresh()
         OptBreedtipCurrentStats25Rare:Disable()
         OptBreedtipAllStats25:Disable()
         OptBreedtipAllStats25Rare:Disable()
+        OptBreedtipCollected:Disable()
     end
 
     if (OptBreedtipCurrentStats25:GetChecked()) then
@@ -391,6 +395,7 @@ local function BPBID_OptTooltipsEnabled_OnClick(self, button, down)
         OptBreedtipCurrentStats25Rare:Enable()
         OptBreedtipAllStats25:Enable()
         OptBreedtipAllStats25Rare:Enable()
+        OptBreedtipCollected:Enable()
         
         -- Restore defaults for previously disabled checkboxes
         BPBID_Options.Tooltips.Enabled = true -- Enable Battle Pet BreedID Tooltips
@@ -424,6 +429,7 @@ local function BPBID_OptTooltipsEnabled_OnClick(self, button, down)
         OptBreedtipCurrentStats25Rare:Disable()
         OptBreedtipAllStats25:Disable()
         OptBreedtipAllStats25Rare:Disable()
+        OptBreedtipCollected:Disable()
         
         -- Uncheck all tooltip-related checkboxes
         BPBID_Options.Tooltips.Enabled = false -- Enable Battle Pet BreedID Tooltips
@@ -465,6 +471,7 @@ local function BPBID_Options_EnableAll()
     OptBreedtipCurrentStats25Rare:Enable()
     OptBreedtipAllStats25:Enable()
     OptBreedtipAllStats25Rare:Enable()
+    OptBreedtipCollected:Enable()
 end
 
 local function BPBID_Options_Default()
@@ -537,6 +544,7 @@ local function BPBID_GeneralCheckbox_OnClick(self, button, down)
     BPBID_Options.Breedtip.CurrentStats25Rare = OptBreedtipCurrentStats25Rare:GetChecked()
     BPBID_Options.Breedtip.AllStats25 = OptBreedtipAllStats25:GetChecked()
     BPBID_Options.Breedtip.AllStats25Rare = OptBreedtipAllStats25Rare:GetChecked()
+    BPBID_Options.Breedtip.Collected = OptBreedtipCollected:GetChecked()
     BPBID_Options.BattleFontFix = OptBugBattleFontFix:GetChecked()
     
     -- Fix fontsize for PrimaryBattlePetUnitTooltip (TODO: PetFrame)
@@ -595,6 +603,7 @@ OptBreedtipCurrentStats:SetScript("OnClick", BPBID_GeneralCheckbox_OnClick)
 OptBreedtipAllStats:SetScript("OnClick", BPBID_GeneralCheckbox_OnClick)
 OptBreedtipCurrentStats25Rare:SetScript("OnClick", BPBID_GeneralCheckbox_OnClick)
 OptBreedtipAllStats25Rare:SetScript("OnClick", BPBID_GeneralCheckbox_OnClick)
+OptBreedtipCollected:SetScript("OnClick", BPBID_GeneralCheckbox_OnClick)
 OptBugBattleFontFix:SetScript("OnClick", BPBID_GeneralCheckbox_OnClick)
 
 -- Reset to Defaults button


### PR DESCRIPTION
A quick comment on why this might be helpful to some people: Since we can have more than 2000 pets now, I've started collecting pets more than once that you can get through pet battles. For some  particular pet battles (e.g. fights and scripts used on wow-petguide.com) the breed actually matters and that's why I'd like to not collect the same breed twice and rather have a variety available for when I might need a special breed. 
This modification allows me to view my collected breeds during the battle without having to browse the pet journal to be able to decide faster whether I want the current pet or not.

<img width="192" alt="image" src="https://github.com/MMOSimca/BattlePetBreedID/assets/14994408/2836a8d2-3066-493b-88fa-f1502869cb2e">

Feel free to edit/comment on UX/UI or possible performance issues (looping though all pets).