### PR TITLE
Tww fixes

### DIFF
--- a/BattlePetBreedID.lua
+++ b/BattlePetBreedID.lua
@@ -44,7 +44,7 @@ internal.MAX_BREEDS = 10
 local PJHooked = false
 
 -- Check if on future build or PTR to enable additional developer functions
-local is_ptr = select(4, _G.GetBuildInfo()) ~= GetAddOnMetadata(addonname, "Interface")
+local is_ptr = select(4, _G.GetBuildInfo()) ~= C_AddOns.GetAddOnMetadata(addonname, "Interface")
 
 -- Takes in lots of information, returns Breed ID as a number (or an error), and the rarity as a number
 function internal.CalculateBreedID(nSpeciesID, nQuality, nLevel, nMaxHP, nPower, nSpeed, wild, flying)

--- a/BreedTooltips.lua
+++ b/BreedTooltips.lua
@@ -69,7 +69,7 @@ function BPBID_SetBreedTooltip(parent, speciesID, tblBreedID, rareness, tooltipD
     -- Workaround for TradeSkillMaster's tooltip
     -- Note that setting parent breaks floating tooltip and setting two corner points breaks borders on TSM tooltip
     -- Setting parent is also required for BattlePetTooltip because TSMExtraTip constantly reanchors itself on its parent
-    if (_G.IsAddOnLoaded("TradeSkillMaster")) then
+    if (C_AddOns.IsAddOnLoaded("TradeSkillMaster")) then
         for i = 1, 10 do
             local t = _G["TSMExtraTip" .. i]
             if t then
@@ -323,7 +323,7 @@ local function BPBID_Hook_BattleUpdate(self)
         if (name) and (BPBID_Options.Names.PrimaryBattle) then
             -- Set standard text or use hex coloring based on font fix option
             if (BPBID_Options.BattleFontFix) then
-                local _, _, _, hex = GetItemQualityColor(internal.rarityCache[self.petIndex + offset] - 1)
+                local _, _, _, hex = C_Item.GetItemQualityColor(internal.rarityCache[self.petIndex + offset] - 1)
                 self.Name:SetText("|c"..hex..name.." ("..breed..")".."|r")
             else
                 self.Name:SetText(name.." ("..breed..")")
@@ -334,7 +334,7 @@ local function BPBID_Hook_BattleUpdate(self)
         if (name) and (BPBID_Options.Names.BattleTooltip) then
             -- Set standard text or use hex coloring based on font fix option
             if (not BPBID_Options.BattleFontFix) then
-                local _, _, _, hex = GetItemQualityColor(internal.rarityCache[self.petIndex + offset] - 1)
+                local _, _, _, hex = C_Item.GetItemQualityColor(internal.rarityCache[self.petIndex + offset] - 1)
                 self.Name:SetText("|c"..hex..name.." ("..breed..")".."|r")
             else
                 self.Name:SetText(name.." ("..breed..")")

--- a/BreedTooltips.lua
+++ b/BreedTooltips.lua
@@ -323,7 +323,7 @@ local function BPBID_Hook_BattleUpdate(self)
         if (name) and (BPBID_Options.Names.PrimaryBattle) then
             -- Set standard text or use hex coloring based on font fix option
             if (BPBID_Options.BattleFontFix) then
-                local _, _, _, hex = C_Item.GetItemQualityColor(internal.rarityCache[self.petIndex + offset] - 1)
+                local _, _, _, hex = C_Item.GetItemQualityColor(internal.rarityCache[self.petIndex + offset])
                 self.Name:SetText("|c"..hex..name.." ("..breed..")".."|r")
             else
                 self.Name:SetText(name.." ("..breed..")")
@@ -334,7 +334,7 @@ local function BPBID_Hook_BattleUpdate(self)
         if (name) and (BPBID_Options.Names.BattleTooltip) then
             -- Set standard text or use hex coloring based on font fix option
             if (not BPBID_Options.BattleFontFix) then
-                local _, _, _, hex = C_Item.GetItemQualityColor(internal.rarityCache[self.petIndex + offset] - 1)
+                local _, _, _, hex = C_Item.GetItemQualityColor(internal.rarityCache[self.petIndex + offset])
                 self.Name:SetText("|c"..hex..name.." ("..breed..")".."|r")
             else
                 self.Name:SetText(name.." ("..breed..")")

--- a/OptionsPanel.lua
+++ b/OptionsPanel.lua
@@ -92,9 +92,9 @@ end
 -- Create title, version, author, and description fields
 local title = CreateFont("GameFontNormalLarge", properName)
 title:SetPoint("TOPLEFT", 16, -16)
-local ver = CreateFont("GameFontNormalSmall", "version "..GetAddOnMetadata(addonname, "Version"))
+local ver = CreateFont("GameFontNormalSmall", "version "..C_AddOns.GetAddOnMetadata(addonname, "Version"))
 ver:SetPoint("BOTTOMLEFT", title, "BOTTOMRIGHT", 4, 0)
-local auth = CreateFont("GameFontNormalSmall", "created by "..GetAddOnMetadata(addonname, "Author"))
+local auth = CreateFont("GameFontNormalSmall", "created by "..C_AddOns.GetAddOnMetadata(addonname, "Author"))
 auth:SetPoint("BOTTOMLEFT", ver, "BOTTOMRIGHT", 3, 0)
 local desc = CreateFont("GameFontHighlight", nil, nil, nil, "TOPLEFT", title, "BOTTOMLEFT", 580, 40, 0, -8, "Battle Pet BreedID displays the BreedID of pets in your journal, in battle, in chat links, and in item tooltips.")
 
@@ -318,7 +318,7 @@ local function BPBID_OptNamesHSFUpdate_OnClick(self, button, down)
     end
     
     -- A manual change has occurred (added in v1.0.8 to help update values added in new versions)
-    BPBID_Options.ManualChange = GetAddOnMetadata(addonname, "Version")
+    BPBID_Options.ManualChange = C_AddOns.GetAddOnMetadata(addonname, "Version")
     
     -- Refresh the options page to display the new values
     BPBID_Options_Refresh()
@@ -335,7 +335,7 @@ local function BPBID_OptNamesPJT_OnClick(self, button, down)
     end
     
     -- A manual change has occurred (added in v1.0.8 to help update values added in new versions)
-    BPBID_Options.ManualChange = GetAddOnMetadata(addonname, "Version")
+    BPBID_Options.ManualChange = C_AddOns.GetAddOnMetadata(addonname, "Version")
     
     -- Refresh the options page to display the new values
     BPBID_Options_Refresh()
@@ -352,7 +352,7 @@ local function BPBID_OptBreedtipCurrentStats25_OnClick(self, button, down)
     end
     
     -- A manual change has occurred (added in v1.0.8 to help update values added in new versions)
-    BPBID_Options.ManualChange = GetAddOnMetadata(addonname, "Version")
+    BPBID_Options.ManualChange = C_AddOns.GetAddOnMetadata(addonname, "Version")
     
     -- Refresh the options page to display the new values
     BPBID_Options_Refresh()
@@ -369,7 +369,7 @@ local function BPBID_OptBreedtipAllStats25_OnClick(self, button, down)
     end
     
     -- A manual change has occurred (added in v1.0.8 to help update values added in new versions)
-    BPBID_Options.ManualChange = GetAddOnMetadata(addonname, "Version")
+    BPBID_Options.ManualChange = C_AddOns.GetAddOnMetadata(addonname, "Version")
     
     -- Refresh the options page to display the new values
     BPBID_Options_Refresh()
@@ -449,7 +449,7 @@ local function BPBID_OptTooltipsEnabled_OnClick(self, button, down)
     end
     
     -- A manual change has occurred (added in v1.0.8 to help update values added in new versions)
-    BPBID_Options.ManualChange = GetAddOnMetadata(addonname, "Version")
+    BPBID_Options.ManualChange = C_AddOns.GetAddOnMetadata(addonname, "Version")
     
     -- Refresh the options page to display the new values
     BPBID_Options_Refresh()
@@ -569,7 +569,7 @@ local function BPBID_GeneralCheckbox_OnClick(self, button, down)
     end
     
     -- A manual change has occurred (added in v1.0.8 to help update values added in new versions)
-    BPBID_Options.ManualChange = GetAddOnMetadata(addonname, "Version")
+    BPBID_Options.ManualChange = C_AddOns.GetAddOnMetadata(addonname, "Version")
     
     -- Refresh the options page to display the new defaults
     BPBID_Options_Refresh()


### PR DESCRIPTION
I have added missing namespaces to several function calls (since calling them without the namespace is deprecated).

Also, in 11.0.0, Blizzard has changed (maybe by mistake, since the documentation doesn't mention it) the color you get from the GetBreedQuality function.
Now it is indexed from 0, so subtracting 1 breaks everything.
It would make sense for it to be on purpose, since everything else related to those colors is indexed from 0.