### PR TITLE
Add categories to TOC

### DIFF
--- a/BattlePetBreedID.toc
+++ b/BattlePetBreedID.toc
@@ -12,7 +12,20 @@
 ## X-WoWI-ID: 23217
 ## SavedVariables: BPBID_Options
 
+## Category: Pet Battles
+## Category-deDE: Haustierkämpfe
+## Category-esES: Duelos de mascotas
+## Category-esMX: Duelos de mascotas
+## Category-frFR: Combats de mascottes
+## Category-itIT: Battaglie fra pet
+## Category-koKR: 애완동물 대전
+## Category-ptBR: Batalhas de mascotes
+## Category-ruRU: Битвы питомцев
+## Category-zhCN: 宠物对战
+## Category-zhTW: 寵物對戰
+
 BattlePetBreedID.lua
 PetData.lua
 BreedTooltips.lua
 OptionsPanel.lua
+


### PR DESCRIPTION
I added the Pet Battles category to the TOC; this makes it group up with other pet battling addons in the WoW addon list.

I debated whether to group it as Pet Battles or Collections; in the end I went with Pet Battles as typically only battlers will care about the breed of a pet. Collectors would just care whether they have any version of the pet or not.

The translations are taken from the suggested list of categories on the WoW wiki: https://warcraft.wiki.gg/wiki/Addon_Categories#Pet_Battles